### PR TITLE
Add decode function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 A `FormURLEncoded` datatype represents an ordered list of key-value pairs
 with possible duplicates. `encode` function allows to transform `FormURLEncoded`
 into a `Maybe String` according to `application/x-www-form-urlencoded`.
+`decode` function transforms a string into a `Maybe FormURLEncoded` structure.
 
 Documentation is available on [Pursuit][Pursuit].
 
@@ -24,6 +25,9 @@ Example:
 >                   , Tuple "Oh" (Just "Let's go!")
 >                   ])
 Just "hey&Oh=Let's%20go!"
+
+> decode "a=aa&b=bb"
+Just (FormURLEncoded [(Tuple "a" (Just "aa")),(Tuple "b" (Just "bb"))])
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A `FormURLEncoded` datatype represents an ordered list of key-value pairs
 with possible duplicates. `encode` function allows to transform `FormURLEncoded`
-into a string according to `application/x-www-form-urlencoded`.
+into a `Maybe String` according to `application/x-www-form-urlencoded`.
 
 Documentation is available on [Pursuit][Pursuit].
 
@@ -23,7 +23,7 @@ Example:
 > encode (fromArray [ Tuple "hey" Nothing
 >                   , Tuple "Oh" (Just "Let's go!")
 >                   ])
-"hey&Oh=Let's%20go!"
+Just "hey&Oh=Let's%20go!"
 ```
 
 ## Contributing

--- a/bower.json
+++ b/bower.json
@@ -14,11 +14,12 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-globals": "^4.0.0",
+    "purescript-globals": "^4.1.0",
     "purescript-maybe": "^4.0.0",
     "purescript-newtype": "^3.0.0",
     "purescript-prelude": "^4.0.0",
     "purescript-strings": "^4.0.0",
-    "purescript-tuples": "^5.0.0"
+    "purescript-tuples": "^5.0.0",
+    "purescript-foldable-traversable": "^4.1.1"
   }
 }

--- a/src/Data/FormURLEncoded.purs
+++ b/src/Data/FormURLEncoded.purs
@@ -5,8 +5,9 @@ import Prelude
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
 import Data.String (joinWith) as String
+import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
-import Global.Unsafe (unsafeEncodeURIComponent)
+import Global (encodeURIComponent)
 
 -- | `FormURLEncoded` is an ordered list of key-value pairs with possible duplicates.
 newtype FormURLEncoded = FormURLEncoded (Array (Tuple String (Maybe String)))
@@ -29,9 +30,9 @@ instance showFormUrlEncoded :: Show FormURLEncoded where
   show (FormURLEncoded kvs) = "(FormURLEncoded " <> show kvs <> ")"
 
 -- | Encode `FormURLEncoded` as `application/x-www-form-urlencoded`.
-encode :: FormURLEncoded -> String
-encode = String.joinWith "&" <<< map encodePart <<< toArray
+encode :: FormURLEncoded -> Maybe String
+encode = map (String.joinWith "&") <<< traverse encodePart <<< toArray
   where
     encodePart = case _ of
-      Tuple k Nothing -> unsafeEncodeURIComponent k
-      Tuple k (Just v) -> unsafeEncodeURIComponent k <> "=" <> unsafeEncodeURIComponent v
+      Tuple k Nothing -> encodeURIComponent k
+      Tuple k (Just v) -> (\key val -> key <> "=" <> val) <$> encodeURIComponent k <*> encodeURIComponent v


### PR DESCRIPTION
## What does this pull request do?

The purpose of this pull request is to extend the library with a function that decodes form data into the `FormURLEncoded` structure.

## Where should the reviewer start?

It's a pretty small change.

## How should this be manually tested?

Here are my test cases:

```
> encode $ decode "a=aa&b=bb"
"a=aa&b=bb"

> encode $ decode "this=this%3Dthis"
"this=this%3Dthis"

> encode $ decode "&x=x&&y=y&z="
"&x=x&&y=y&z="

> decode "a=aa&b=bb"
(FormURLEncoded [(Tuple "a" (Just "aa")),(Tuple "b" (Just "bb"))])

> decode "this=this%3Dthis"
(FormURLEncoded [(Tuple "this" (Just "this=this"))])

> decode "&x=x&&y=y&z="
(FormURLEncoded [(Tuple "" Nothing),(Tuple "x" (Just "x")),(Tuple "" Nothing),(Tuple "y" (Just "y")),(Tuple "z" (Just ""))])
```

## Other Notes:

I already updated the README, and I don't think any follow-up steps are necessary other than cutting a release.