### PR TITLE
Make encode function safe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A `FormURLEncoded` datatype represents an ordered list of key-value pairs
 with possible duplicates. `encode` function allows to transform `FormURLEncoded`
-into a string according to `application/x-www-form-urlencoded`.
+into a `Maybe String` according to `application/x-www-form-urlencoded`.
 
 Documentation is available on [Pursuit][Pursuit].
 
@@ -23,7 +23,7 @@ Example:
 > encode (fromArray [ Tuple "hey" Nothing
 >                   , Tuple "Oh" (Just "Let's go!")
 >                   ])
-"hey&Oh=Let's%20go!"
+Just "hey&Oh=Let's%20go!"
 ```
 
 ## Contributing

--- a/bower.json
+++ b/bower.json
@@ -14,11 +14,12 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-globals": "^4.0.0",
+    "purescript-globals": "^4.1.0",
     "purescript-maybe": "^4.0.0",
     "purescript-newtype": "^3.0.0",
     "purescript-prelude": "^4.0.0",
     "purescript-strings": "^4.0.0",
-    "purescript-tuples": "^5.0.0"
+    "purescript-tuples": "^5.0.0",
+    "purescript-foldable-traversable": "^4.1.1"
   }
 }

--- a/src/Data/FormURLEncoded.purs
+++ b/src/Data/FormURLEncoded.purs
@@ -5,8 +5,9 @@ import Prelude
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
 import Data.String (joinWith) as String
+import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
-import Global.Unsafe (unsafeEncodeURIComponent)
+import Global (encodeURIComponent)
 
 -- | `FormURLEncoded` is an ordered list of key-value pairs with possible duplicates.
 newtype FormURLEncoded = FormURLEncoded (Array (Tuple String (Maybe String)))
@@ -29,9 +30,9 @@ instance showFormUrlEncoded :: Show FormURLEncoded where
   show (FormURLEncoded kvs) = "(FormURLEncoded " <> show kvs <> ")"
 
 -- | Encode `FormURLEncoded` as `application/x-www-form-urlencoded`.
-encode :: FormURLEncoded -> String
-encode = String.joinWith "&" <<< map encodePart <<< toArray
+encode :: FormURLEncoded -> Maybe String
+encode = map (String.joinWith "&") <<< traverse encodePart <<< toArray
   where
     encodePart = case _ of
-      Tuple k Nothing -> unsafeEncodeURIComponent k
-      Tuple k (Just v) -> unsafeEncodeURIComponent k <> "=" <> unsafeEncodeURIComponent v
+      Tuple k Nothing -> encodeURIComponent k
+      Tuple k (Just v) -> (\key val -> key <> "=" <> val) <$> encodeURIComponent k <*> encodeURIComponent v


### PR DESCRIPTION
## What does this pull request do?

This pull request is a follow-up to #12 as well as [purescript-globals#18](https://github.com/purescript/purescript-globals/pull/18). With a safe `encodeURIComponent` function available in purescript-globals as of 4.1.0, we can surface possible failure in this library's `encode` API by changing its type to `FormURLEncoded -> Maybe String`.

## Where should the reviewer start?

You will find that the code changes involved are minimal.

## How should this be manually tested?

I figured that verifying the example shown in the README (including my small update) was a sensible test:

> encode $ fromArray [ Tuple "hey" Nothing, Tuple "Oh" $ Just "Let's go!" ]
(Just "hey&Oh=Let's%20go!")

## Other Notes:

* I already updated the README, so no follow-up should be required there.
* At the risk of stating the obvious, this is a breaking API change.
* I will update #12 if and when this pull request is merged.

One more thing... Thanks @thomashoneyman and @garyb for your suggestions and for making this possible to implement by updating purescript-globals.