### PR TITLE
Fixed encoding of spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ New features:
 
 Bugfixes:
 
-- Fixed encoding of spaces. Spaces must be replaced by `+` instead of `%20`
+- Fixed encoding of spaces. Spaces must be replaced by `+` instead of `%20` (#24 by @dederer)
 
 Other improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ New features:
 
 Bugfixes:
 
+- Fixed encoding of spaces. Spaces must be replaced by `+` instead of `%20`
+
 Other improvements:
 
 ## [v6.0.0](https://github.com/purescript-contrib/purescript-form-urlencoded/releases/tag/v6.0.0) - 2021-02-26

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use the `encode` function to properly encode an array of key-value pairs, and th
 >   [ Tuple "hey" Nothing
 >   , Tuple "Oh" (Just "Let's go!")
 >   ]
-Just "hey&Oh=Let's%20go!"
+Just "hey&Oh=Let's+go!"
 
 > decode "a=aa&b=bb"
 Just (FormURLEncoded [(Tuple "a" (Just "aa")),(Tuple "b" (Just "bb"))])

--- a/src/Data/FormURLEncoded.purs
+++ b/src/Data/FormURLEncoded.purs
@@ -8,7 +8,7 @@ import Data.String (joinWith, split) as String
 import Data.String.Pattern (Pattern(..))
 import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
-import JSURI (decodeURIComponent, encodeURIComponent)
+import JSURI (decodeFormURLComponent, encodeFormURLComponent)
 
 -- | `FormURLEncoded` is an ordered list of key-value pairs with possible duplicates.
 newtype FormURLEncoded = FormURLEncoded (Array (Tuple String (Maybe String)))
@@ -35,14 +35,14 @@ encode :: FormURLEncoded -> Maybe String
 encode = map (String.joinWith "&") <<< traverse encodePart <<< toArray
   where
     encodePart = case _ of
-      Tuple k Nothing -> encodeURIComponent k
-      Tuple k (Just v) -> (\key val -> key <> "=" <> val) <$> encodeURIComponent k <*> encodeURIComponent v
+      Tuple k Nothing -> encodeFormURLComponent k
+      Tuple k (Just v) -> (\key val -> key <> "=" <> val) <$> encodeFormURLComponent k <*> encodeFormURLComponent v
 
 -- | Decode `FormURLEncoded` from `application/x-www-form-urlencoded`.
 decode :: String -> Maybe FormURLEncoded
 decode = map FormURLEncoded <<< traverse decodePart <<< String.split (Pattern "&")
   where
     decodePart = String.split (Pattern "=") >>> case _ of
-      [k, v] -> (\key val -> Tuple key $ Just val) <$> decodeURIComponent k <*> decodeURIComponent v
-      [k]    -> Tuple <$> decodeURIComponent k <*> pure Nothing
+      [k, v] -> (\key val -> Tuple key $ Just val) <$> decodeFormURLComponent k <*> decodeFormURLComponent v
+      [k]    -> Tuple <$> decodeFormURLComponent k <*> pure Nothing
       _      -> Nothing

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -27,6 +27,8 @@ main = do
 
   testDecode "a=b&%8A=c" Nothing
 
+  testDecode "a+b=aa+bb" (Just $ FormURLEncoded [ Tuple "a b" $ Just "aa bb" ])
+
   testEncode (FormURLEncoded [ Tuple "a" $ Just "aa", Tuple "b" $ Just "bb" ]) $ Just "a=aa&b=bb"
 
   testEncode (FormURLEncoded [ Tuple "this" $ Just "this=this" ]) $ Just "this=this%3Dthis"
@@ -40,6 +42,8 @@ main = do
       , Tuple "z" $ Just ""
       ])
     (Just "&x=x&&y=y&z=")
+
+  testEncode (FormURLEncoded [ Tuple "a b" $ Just "aa bb" ]) $ Just "a+b=aa+bb"
 
   where
 


### PR DESCRIPTION
Spaces must be encoded as "+" (#23). To fix it, I replaced functions `encodeURIComponent` and `decodeURIComponent` with `encodeFormURLComponent` and `decodeFormURLComponent`, corrected the sample code in the README.md file, and added tests.