### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -31,3 +33,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#26 by @thomashoneyman)
 
 ## [v6.0.2](https://github.com/purescript-contrib/purescript-form-urlencoded/releases/tag/v6.0.2) - 2021-06-16
 

--- a/src/Data/FormURLEncoded.purs
+++ b/src/Data/FormURLEncoded.purs
@@ -34,15 +34,15 @@ instance showFormUrlEncoded :: Show FormURLEncoded where
 encode :: FormURLEncoded -> Maybe String
 encode = map (String.joinWith "&") <<< traverse encodePart <<< toArray
   where
-    encodePart = case _ of
-      Tuple k Nothing -> encodeFormURLComponent k
-      Tuple k (Just v) -> (\key val -> key <> "=" <> val) <$> encodeFormURLComponent k <*> encodeFormURLComponent v
+  encodePart = case _ of
+    Tuple k Nothing -> encodeFormURLComponent k
+    Tuple k (Just v) -> (\key val -> key <> "=" <> val) <$> encodeFormURLComponent k <*> encodeFormURLComponent v
 
 -- | Decode `FormURLEncoded` from `application/x-www-form-urlencoded`.
 decode :: String -> Maybe FormURLEncoded
 decode = map FormURLEncoded <<< traverse decodePart <<< String.split (Pattern "&")
   where
-    decodePart = String.split (Pattern "=") >>> case _ of
-      [k, v] -> (\key val -> Tuple key $ Just val) <$> decodeFormURLComponent k <*> decodeFormURLComponent v
-      [k]    -> Tuple <$> decodeFormURLComponent k <*> pure Nothing
-      _      -> Nothing
+  decodePart = String.split (Pattern "=") >>> case _ of
+    [ k, v ] -> (\key val -> Tuple key $ Just val) <$> decodeFormURLComponent k <*> decodeFormURLComponent v
+    [ k ] -> Tuple <$> decodeFormURLComponent k <*> pure Nothing
+    _ -> Nothing

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -48,7 +48,6 @@ main = do
   testEncode (FormURLEncoded [ Tuple "a b" $ Just "aa bb" ]) $ Just "a+b=aa+bb"
 
   where
-
   testDecode :: String -> Maybe FormURLEncoded -> Effect Unit
   testDecode input expected =
     (log $ "decode \"" <> input <> "\" == " <> show expected) *> assert (decode input == expected)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -16,14 +16,15 @@ main = do
 
   testDecode "this=this%3Dthis" (Just $ FormURLEncoded [ Tuple "this" $ Just "this=this" ])
 
-  testDecode "&x=x&&y=y&z=" $
-    Just $ FormURLEncoded
-      [ Tuple "" Nothing
-      , Tuple "x" $ Just "x"
-      , Tuple "" Nothing
-      , Tuple "y" $ Just "y"
-      , Tuple "z" $ Just ""
-      ]
+  testDecode "&x=x&&y=y&z="
+    $ Just
+    $ FormURLEncoded
+        [ Tuple "" Nothing
+        , Tuple "x" $ Just "x"
+        , Tuple "" Nothing
+        , Tuple "y" $ Just "y"
+        , Tuple "z" $ Just ""
+        ]
 
   testDecode "a=b&%8A=c" Nothing
 
@@ -34,23 +35,24 @@ main = do
   testEncode (FormURLEncoded [ Tuple "this" $ Just "this=this" ]) $ Just "this=this%3Dthis"
 
   testEncode
-    (FormURLEncoded
-      [ Tuple "" Nothing
-      , Tuple "x" $ Just "x"
-      , Tuple "" Nothing
-      , Tuple "y" $ Just "y"
-      , Tuple "z" $ Just ""
-      ])
+    ( FormURLEncoded
+        [ Tuple "" Nothing
+        , Tuple "x" $ Just "x"
+        , Tuple "" Nothing
+        , Tuple "y" $ Just "y"
+        , Tuple "z" $ Just ""
+        ]
+    )
     (Just "&x=x&&y=y&z=")
 
   testEncode (FormURLEncoded [ Tuple "a b" $ Just "aa bb" ]) $ Just "a+b=aa+bb"
 
   where
 
-    testDecode :: String -> Maybe FormURLEncoded -> Effect Unit
-    testDecode input expected =
-      (log $ "decode \"" <> input <> "\" == " <> show expected) *> assert (decode input == expected)
+  testDecode :: String -> Maybe FormURLEncoded -> Effect Unit
+  testDecode input expected =
+    (log $ "decode \"" <> input <> "\" == " <> show expected) *> assert (decode input == expected)
 
-    testEncode :: FormURLEncoded -> Maybe String -> Effect Unit
-    testEncode input expected =
-      (log $ "encode " <> show input <> " == \"" <> show expected <> "\"") *> assert (encode input == expected)
+  testEncode :: FormURLEncoded -> Maybe String -> Effect Unit
+  testEncode input expected =
+    (log $ "encode " <> show input <> " == \"" <> show expected <> "\"") *> assert (encode input == expected)


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
